### PR TITLE
Lower Version Requirement + Add PathGenerator support.

### DIFF
--- a/lib/valkyrie/storage/shrine.rb
+++ b/lib/valkyrie/storage/shrine.rb
@@ -38,7 +38,7 @@ module Valkyrie
       # @raise Valkyrie::Shrine::IntegrityError if #verify_checksum is defined
       #   on the shrine object and the file and result digests do not match
       def upload(file:, original_filename:, resource:, **upload_options)
-        identifier = path_generator.generate(resource: resource, file: file, original_filename: original_filename)
+        identifier = path_generator.generate(resource: resource, file: file, original_filename: original_filename).to_s
         shrine.upload(file, identifier, **upload_options)
         find_by(id: "#{PROTOCOL}#{identifier}").tap do |result|
           if verifier

--- a/lib/valkyrie/storage/shrine.rb
+++ b/lib/valkyrie/storage/shrine.rb
@@ -8,7 +8,7 @@ module Valkyrie
     class Shrine
       PROTOCOL = 'shrine://'
 
-      attr_reader :shrine, :verifier
+      attr_reader :shrine, :verifier, :path_generator
 
       class IDPathGenerator
         def initialize(base_path: nil)

--- a/valkyrie-shrine.gemspec
+++ b/valkyrie-shrine.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk-s3', '~> 1'
   spec.add_dependency 'shrine', '~> 2.0'
-  spec.add_dependency 'valkyrie', '~> 2.0.0.RC3'
+  spec.add_dependency 'valkyrie', '> 1.0'
 
   spec.add_development_dependency 'bixby', '~> 2.0.0.pre.beta1'
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
These were just a couple changes I had to do to get Figgy to use the gem for preserving items in Google Cloud Storage.