### PR TITLE
open up support for Shrine 3 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.1
+      - image: cimg/ruby:2.6.1
         environment:
           BUNDLER_VERSION: 2.0.1
     steps:

--- a/lib/valkyrie/shrine/checksum/s3.rb
+++ b/lib/valkyrie/shrine/checksum/s3.rb
@@ -16,7 +16,8 @@ module Valkyrie
         end
 
         def calculate_checksum(result)
-          result.io.data[:object].data.etag.delete('"')
+          result.io.data[:object]&.data&.etag&.delete('"') ||
+            checksum_for(result.io)
         end
 
         def checksum_for(io)

--- a/spec/support/fixture_path.rb
+++ b/spec/support/fixture_path.rb
@@ -3,6 +3,10 @@ module FixturePath
   def fixture_path
     RSpec.configuration.fixture_path
   end
+
+  def file_fixture_path
+    RSpec.configuration.fixture_path
+  end
 end
 RSpec.configure do |config|
   config.add_setting :fixture_path

--- a/spec/valkyrie/storage/shrine_spec.rb
+++ b/spec/valkyrie/storage/shrine_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Valkyrie::Storage::Shrine do
     end
     it "only reads from the client when the content is actually read out" do
       allow(s3_adapter).to receive(:open).and_call_original
-      uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: ExampleResource.new, fake_upload_argument: true)
+      uploaded_file = storage_adapter.upload(file: file, original_filename: 'foo.jpg', resource: ExampleResource.new(id: 'fake_id'), fake_upload_argument: true)
 
       expect(s3_adapter).not_to have_received(:open)
       uploaded_file.read

--- a/valkyrie-shrine.gemspec
+++ b/valkyrie-shrine.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk-s3', '~> 1'
-  spec.add_dependency 'shrine', '~> 2.0'
+  spec.add_dependency 'shrine', '>= 2.0', '< 4.0'
   spec.add_dependency 'valkyrie', '> 1.0'
 
   spec.add_development_dependency 'bixby', '~> 2.0.0.pre.beta1'


### PR DESCRIPTION
Shrine 2 is out of support and missing security patches. this gem should support shrine 3.