### PR TITLE
Add #protocol method required by Valkyrie 3.5 to Valkyrie::Storage::Shrine

### DIFF
--- a/lib/valkyrie/storage/shrine.rb
+++ b/lib/valkyrie/storage/shrine.rb
@@ -104,10 +104,15 @@ module Valkyrie
         shrine.delete(shrine_id_for(id))
       end
 
-      # @param feature [Symbol] Feature to test for.
+      # @param _feature [Symbol] Feature to test for.
       # @return [Boolean] true if the adapter supports the given feature
       def supports?(_feature)
         false
+      end
+
+      # @return [String] identifier prefix
+      def protocol
+        protocol_with_prefix
       end
 
       private


### PR DESCRIPTION
Minor update to fix some test failures that appear when running a fresh checkout with Bundler installing Valkyrie 3.5.0.

1. Implements `#protocol` as required by https://github.com/samvera/valkyrie/pull/974
2. Modifies `shrine_spec.rb` to pass `identifier_prefix` to the storage adapter under test rather than to the S3 adapter (seems like it was probably a long-standing typo?)