### PR TITLE
Support Versioning on AWS/S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Follow the Valkyrie [README](https://github.com/samvera-labs/valkyrie) to get a 
   # config/initializers/valkyrie.rb
   require 'shrine/storage/s3'
   require 'shrine/storage/file_system'
-  require 'valkyrie/storage/shrine/checksum/s3'
-  require 'valkyrie/storage/shrine/checksum/file_system'
+  require 'valkyrie/shrine/checksum/s3'
+  require 'valkyrie/shrine/checksum/file_system'
+  require 'valkyrie/shrine/storage/s3'
 
   Shrine.storages = {
     file: Shrine::Storage::FileSystem.new("public", prefix: "uploads"),
@@ -35,6 +36,18 @@ Follow the Valkyrie [README](https://github.com/samvera-labs/valkyrie) to get a 
 
   Valkyrie::StorageAdapter.register(
     Valkyrie::Storage::Shrine.new(Shrine.storages[:file]), :disk
+  )
+
+  s3_options = {
+    access_key_id: s3_access_key,
+    bucket: s3_bucket,
+    endpoint: s3_endpoint,
+    force_path_style: force_path_style,
+    region: s3_region,
+    secret_access_key: s3_secret_key
+  }
+  Valkyrie::StorageAdapter.register(
+    Valkyrie::Storage::VersionedShrine.new(Valkyrie::Shrine::Storage::S3.new(**s3_options)), :versioned_s3
   )
 ```
 

--- a/lib/valkyrie/shrine.rb
+++ b/lib/valkyrie/shrine.rb
@@ -5,6 +5,8 @@ require 'valkyrie/storage/shrine'
 require 'valkyrie/shrine/checksum/base'
 require 'valkyrie/shrine/checksum/file_system'
 require 'valkyrie/shrine/checksum/s3'
+require 'valkyrie/shrine/storage/s3'
+require 'valkyrie/storage/versioned_shrine'
 
 module Valkyrie
   module Shrine

--- a/lib/valkyrie/shrine/storage/s3.rb
+++ b/lib/valkyrie/shrine/storage/s3.rb
@@ -13,8 +13,11 @@ module Valkyrie
         # @param id_prefix [String] - object's id that starts with
         # @return [Array(String)]
         def list_object_ids(id_prefix:)
-          bucket.objects(prefix: [*prefix, id_prefix].join("/"))
-                .map { |obj| (prefix.present? ? obj.key.sub(/^#{prefix}\//, "") : obj.key) }
+          aws_prefix = [*prefix, id_prefix].join("/")
+          keys = bucket.objects(prefix: aws_prefix).map(&:key)
+          return keys if prefix.blank?
+
+          keys.map { |k| k.delete_prefix("#{prefix}/") }
         end
       end
     end

--- a/lib/valkyrie/shrine/storage/s3.rb
+++ b/lib/valkyrie/shrine/storage/s3.rb
@@ -50,14 +50,14 @@ module Valkyrie
 
         private
 
-        # @ return list of object id's
-        # @param objects [Array(Aws::S3::Object)]
-        def object_ids_for(objects)
-          keys = objects.map(&:key)
-          return keys if prefix.blank?
+          # @ return list of object id's
+          # @param objects [Array(Aws::S3::Object)]
+          def object_ids_for(objects)
+            keys = objects.map(&:key)
+            return keys if prefix.blank?
 
-          keys.map { |k| k.delete_prefix("#{prefix}/") }
-        end
+            keys.map { |k| k.delete_prefix("#{prefix}/") }
+          end
       end
     end
   end

--- a/lib/valkyrie/shrine/storage/s3.rb
+++ b/lib/valkyrie/shrine/storage/s3.rb
@@ -6,6 +6,17 @@ module Valkyrie
   module Shrine
     module Storage
       class S3 < ::Shrine::Storage::S3
+        # List objects that are starting with a given prefix.
+        # This is helpful for versioned files that have a common file identifier.
+        # Need to make sure to combine with storage prefix.
+        #    list_objects(id_prefix: "some/object/id")
+        # @param id_prefix [String] - object's id that starts with
+        # @return [Array(Aws::S3::Object)]
+        def list_objects(id_prefix:)
+          aws_prefix = [*prefix, id_prefix].join("/")
+          bucket.objects(prefix: aws_prefix)
+        end
+
         # List objects id's that are starting with a given prefix.
         # This is helpful for versioned files that have a common file identifier.
         # Need to make sure to combine with storage prefix.
@@ -13,11 +24,8 @@ module Valkyrie
         # @param id_prefix [String] - object's id that starts with
         # @return [Array(String)]
         def list_object_ids(id_prefix:)
-          aws_prefix = [*prefix, id_prefix].join("/")
-          keys = bucket.objects(prefix: aws_prefix).map(&:key)
-          return keys if prefix.blank?
-
-          keys.map { |k| k.delete_prefix("#{prefix}/") }
+          objects = list_objects(id_prefix: id_prefix)
+          object_ids_for(objects)
         end
 
         # Move a file to a another location.
@@ -30,6 +38,25 @@ module Valkyrie
           destination_key = "#{destination_bucket}/#{object_key(destination_id)}"
           source_object.move_to(destination_key)
           destination_key
+        end
+
+        # Deletes all objects in fewest requests possible.
+        # @see +super#delete_objects(objects)+.
+        # @return [Array(string)] List of object id's that are deleted
+        def delete_objects(objects)
+          super
+          object_ids_for(objects)
+        end
+
+        private
+
+        # @ return list of object id's
+        # @param objects [Array(Aws::S3::Object)]
+        def object_ids_for(objects)
+          keys = objects.map(&:key)
+          return keys if prefix.blank?
+
+          keys.map { |k| k.delete_prefix("#{prefix}/") }
         end
       end
     end

--- a/lib/valkyrie/shrine/storage/s3.rb
+++ b/lib/valkyrie/shrine/storage/s3.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "shrine/storage/s3"
+
+module Valkyrie
+  module Shrine
+    module Storage
+      class S3 < ::Shrine::Storage::S3
+        # List objects id's that are starting with a given prefix.
+        # This is helpful for versioned files that have a common file identifier.
+        # Need to make sure to combine with storage prefix.
+        #    list_object_ids(id_prefix: "some/object/id")
+        # @param id_prefix [String] - object's id that starts with
+        # @return [Array(String)]
+        def list_object_ids(id_prefix:)
+          bucket.objects(prefix: [*prefix, id_prefix].join("/"))
+                .map { |obj| (prefix.present? ? obj.key.sub(/^#{prefix}\//, "") : obj.key) }
+        end
+      end
+    end
+  end
+end

--- a/lib/valkyrie/shrine/storage/s3.rb
+++ b/lib/valkyrie/shrine/storage/s3.rb
@@ -19,6 +19,18 @@ module Valkyrie
 
           keys.map { |k| k.delete_prefix("#{prefix}/") }
         end
+
+        # Move a file to a another location.
+        # @param id [String] - the id of the source file
+        # @param destination_id [String] - the id of the destination file
+        # @param destination_bucket [String] - the bucket name of the destination
+        # @return [String]
+        def move_to(id:, destination_id:, destination_bucket: bucket.name)
+          source_object = Aws::S3::Object.new(bucket.name, object_key(id), client: client)
+          destination_key = "#{destination_bucket}/#{object_key(destination_id)}"
+          source_object.move_to(destination_key)
+          destination_key
+        end
       end
     end
   end

--- a/lib/valkyrie/storage/versioned_shrine.rb
+++ b/lib/valkyrie/storage/versioned_shrine.rb
@@ -65,7 +65,7 @@ module Valkyrie
         # For backward compatablity with files ingested in the past and we don't have to migrate it to versioned fies.
         #   If there is a file associated with the given identifier that is not a versioned file,
         #   simply convert it to a versioned file basing on last_modified time to keep all versioned files consistent.
-        to_version_file(id: id) if shrine.exists?(shrine_id_for(id))
+        migrate_to_versioned(id: id) if shrine.exists?(shrine_id_for(id))
 
         upload_file(file: file, identifier: versioned_shrine_id, **upload_options)
       end
@@ -121,7 +121,7 @@ module Valkyrie
       # Convert a non-versioned file to a version file basing on its last_modified time.
       # @param id [Valkyrie::ID]
       # @return [VerrsionId]
-      def to_version_file(id:)
+      def migrate_to_versioned(id:)
         shrine_id = shrine_id_for(id)
         last_modified = shrine.object(shrine_id).last_modified
         version_id = VersionId.new(id).generate_version(timestamp: last_modified).id

--- a/lib/valkyrie/storage/versioned_shrine.rb
+++ b/lib/valkyrie/storage/versioned_shrine.rb
@@ -132,8 +132,7 @@ module Valkyrie
         shrine_id = shrine_id_for(id)
         last_modified = shrine.object(shrine_id).last_modified
         version_id = VersionId.new(id).generate_version(timestamp: last_modified).id
-        source_object = Aws::S3::Object.new(shrine.bucket.name, shrine_id, client: shrine.client)
-        source_object.move_to("#{shrine.bucket.name}/#{shrine_id_for(version_id)}")
+        shrine.move_to(id: shrine_id, destination_id: shrine_id_for(version_id))
         version_id
       end
 

--- a/lib/valkyrie/storage/versioned_shrine.rb
+++ b/lib/valkyrie/storage/versioned_shrine.rb
@@ -29,18 +29,17 @@ module Valkyrie
       # @param id [Valkyrie::ID]
       # @return [Array(Valkyrie::StorageAdapter::StreamFile)]
       def find_versions(id:)
-        version_files(id: id)
-          .map { |f| find_by(id: Valkyrie::ID.new(f)) }
+        version_files(id: id).map { |f| find_by(id: f) }
       end
 
       # Retireve all file versions associated with the given identifier from S3
       # @param id [Valkyrie::ID]
-      # @return [Array(String))] - list of file identifiers
+      # @return [Array(Valkyrie::ID)] - list of file identifiers
       def version_files(id:)
         shrine.list_object_ids(id_prefix: shrine_id_for(id))
               .sort
               .reverse
-              .map { |v| protocol_with_prefix + v }
+              .map { |v| Valkyrie::ID.new(protocol_with_prefix + v) }
       end
 
       # Upload a file via the VersionedShrine storage adapter with a version id assigned.
@@ -83,7 +82,7 @@ module Valkyrie
       def delete(id:)
         version_id = VersionId.new(id)
 
-        delete_ids = version_id.versioned? ? [resolve_current(id)&.id].compact : version_files(id: id).map { |f| Valkyrie::ID.new(f) }
+        delete_ids = version_id.versioned? ? [resolve_current(id)&.id].compact : version_files(id: id)
 
         delete_ids.each do |delete_id|
           shrine_id_to_delete = shrine_id_for(delete_id)

--- a/lib/valkyrie/storage/versioned_shrine.rb
+++ b/lib/valkyrie/storage/versioned_shrine.rb
@@ -120,12 +120,14 @@ module Valkyrie
 
       # Convert a non-versioned file to a version file basing on its last_modified time.
       # @param id [Valkyrie::ID]
+      # @return [VerrsionId]
       def to_version_file(id:)
         shrine_id = shrine_id_for(id)
         last_modified = shrine.object(shrine_id).last_modified
         version_id = VersionId.new(id).generate_version(timestamp: last_modified).id
         source_object = Aws::S3::Object.new(shrine.bucket.name, shrine_id, client: shrine.client)
         source_object.move_to("#{shrine.bucket.name}/#{shrine_id_for(version_id)}")
+        version_id
       end
 
       # A class that holds a version id and methods for knowing things about it.

--- a/lib/valkyrie/storage/versioned_shrine.rb
+++ b/lib/valkyrie/storage/versioned_shrine.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+module Valkyrie
+  module Storage
+    # The VersionedShrine adapter implements versioned storage on S3 that manages versions
+    # through Shrine object id with a timestamp like shrine://[resource_id]/[UUID]_v-[timestamp].
+    #
+    # Example to use VersionedShrine storage adapter:
+    #    shrine_s3_options = {
+    #      access_key_id: s3_access_key,
+    #      bucket: s3_bucket,
+    #      endpoint: s3_endpoint,
+    #      force_path_style: force_path_style,
+    #      region: s3_region,
+    #      secret_access_key: s3_secret_key
+    #    }
+    #    Valkyrie::StorageAdapter.register(
+    #      Valkyrie::Storage::VersionedShrine.new(Valkyrie::Shrine::Storage::S3.new(**shrine_s3_options)),
+    #      :s3_repository
+    #    )
+    class VersionedShrine < Shrine
+      # @param feature [Symbol] Feature to test for.
+      # @return [Boolean] true if the adapter supports the given feature
+      def supports?(feature)
+        return true if feature == :versions || feature == :version_deletion
+        false
+      end
+
+      # Retireve all files versions with no deletion marker that are associated from S3.
+      # @param id [Valkyrie::ID]
+      # @return [Array(Valkyrie::StorageAdapter::StreamFile)]
+      def find_versions(id:)
+        version_files(id: id)
+          .reject { |f| VersionId.new(f).deletion_marker? }
+          .map { |f| find_by(id: Valkyrie::ID.new(f)) }
+      end
+
+      # Retireve all file versions associated with the given identifier from S3
+      # @param id [Valkyrie::ID]
+      # @return [Array(String))] - list of file identifiers
+      def version_files(id:)
+        shrine.list_object_ids(id_prefix: shrine_id_for(id))
+              .sort
+              .reverse
+              .map { |v| protocol_with_prefix + v }
+      end
+
+      # Upload a file via the VersionedShrine storage adapter with a version id assigned.
+      # @param file [IO]
+      # @param original_filename [String]
+      # @param resource [Valkyrie::Resource]
+      # @return [Valkyrie::StorageAdapter::StreamFile]
+      # @raise Valkyrie::Shrine::IntegrityError if #verify_checksum is defined
+      #   on the shrine object and the file and result digests do not match
+      def upload(file:, original_filename:, resource:, **upload_options)
+        identifier = path_generator.generate(resource: resource, file: file, original_filename: original_filename)
+        identifier = VersionId.new(Valkyrie::ID.new(identifier)).generate_version.string_id
+        upload_file(file: file, identifier: identifier, **upload_options)
+      end
+
+      # Upload a new version file
+      # @param id [Valkyrie::ID] ID of the Valkyrie::StorageAdapter::File to version.
+      # @param file [IO]
+      def upload_version(id:, file:, **upload_options)
+        versioned_shrine_id = shrine_id_for(VersionId.new(id).generate_version.id)
+        uploaded_version = upload_file(file: file, identifier: versioned_shrine_id, **upload_options)
+
+        # For backward compatablity with files ingested in the past and we don't have to migrate it to versioned fies.
+        #   If there is a file associated with the given identifier that is not a versioned file,
+        #   simply convert it to a versioned file basing on last_modified time to keep all versioned files consistent.
+        to_version_file(id: id) if shrine.exists?(shrine_id_for(id))
+
+        uploaded_version
+      end
+
+      # Delete the versioned file or delete all versions in S3 associated with the given identifier.
+      # @param id [Valkyrie::ID]
+      # @return [Array(Valkyrie::ID)] - file id's that are deleted.
+      def delete(id:)
+        version_id = VersionId.new(id)
+        return [] if version_id.deletion_marker?
+
+        delete_ids = version_id.versioned? ? [id] : version_files(id: id).map { |f| Valkyrie::ID.new(f) }
+
+        delete_ids.reject { |f| VersionId.new(f).deletion_marker? }.map do |delete_id|
+          delete_id = version_id(delete_id).id # convert id with current reference.
+          shrine_id_to_delete = shrine_id_for(delete_id)
+          next unless shrine.exists?(shrine_id_to_delete)
+
+          shrine.delete(shrine_id_to_delete)
+
+          # Mark the object with deletion marker
+          deletion_marker_id = Valkyrie::ID.new("#{delete_id}-#{VersionId::DELETION_MARKER}")
+          shrine.object(shrine_id_for(deletion_marker_id)).put
+          deletion_marker_id
+        end
+      end
+
+      # Find the file associated with the given version identifier
+      #
+      # Note: we need override it to use the latest version
+      #   so that file characterization and derivative creation can use the latest file uploaded
+      # @param id [Valkyrie::ID]
+      # @return [Valkyrie::StorageAdapter::StreamFile]
+      # @raise Valkyrie::StorageAdapter::FileNotFound if nothing is found
+      def find_by(id:)
+        id = if VersionId.new(id).versioned?
+               id
+             else
+               Valkyrie::ID.new(version_files(id: id).first || id.to_s)
+             end
+
+        raise Valkyrie::StorageAdapter::FileNotFound unless shrine.exists?(shrine_id_for(id)) && !id.to_s.include?(VersionId::DELETION_MARKER)
+        Valkyrie::StorageAdapter::StreamFile.new(id: Valkyrie::ID.new(id.to_s.split(VersionId::VERSION_PREFIX).first),
+                                                 io: DelayedDownload.new(shrine, shrine_id_for(id)),
+                                                 version_id: id)
+      end
+
+      # @return VersionId A VersionId value that's resolved a current reference,
+      #   so we can access the `version_id` and current reference.
+      def version_id(id)
+        version_id = VersionId.new(id)
+        return version_id unless version_id.versioned? && version_id.reference?
+        id = Valkyrie::ID.new(id.to_s.split(VersionId::VERSION_PREFIX).first)
+        version_files(id: id).map { |f| VersionId.new(f) }
+                             .reject { |f| VersionId.new(f).deletion_marker? }
+                             .first
+      end
+
+      # Convert a non-versioned file to a version file basing on its last_modified time.
+      # @param id [Valkyrie::ID]
+      def to_version_file(id:)
+        shrine_id = shrine_id_for(id)
+        last_modified = shrine.object(shrine_id).last_modified
+        version_id = VersionId.new(id).generate_version(timestamp: last_modified).id
+        source_object = Aws::S3::Object.new(shrine.bucket.name, shrine_id, client: shrine.client)
+        source_object.move_to("#{shrine.bucket.name}/#{shrine_id_for(version_id)}")
+      end
+
+      # A class that holds a version id and methods for knowing things about it.
+      # Examples of version ids in this adapter:
+      #   * shrine://[resource_id]/[uuid]_v-current
+      #   * shrine://[resource_id]/[uuid]_v-1694195675462560794
+      #   * shrine://[resource_id]/[uuid]_v-1694195675462560794-deletionmarker
+      class VersionId
+        VERSION_PREFIX = "_v-"
+        CURRENT_VERSION = "current"
+        DELETION_MARKER = "deletionmarker"
+
+        attr_reader :id
+        def initialize(id)
+          @id = id
+        end
+
+        # Generate new version identifier basing on the given identifier, which could be the original file identifier like
+        #   shrine://[resource_id]/[uuid], or a version identifier like shrine://[resource_id]/[uuid]_v-1694195675462560794.
+        # @param timestamp [Time]
+        # @return [VersionID]
+        def generate_version(timestamp: nil)
+          version_timestam = timestamp.respond_to?(:strftime) ? timestamp.strftime("%s%L") : timestamp || current_timestamp
+          id_string = if versioned?
+                        string_id.gsub(version, version_timestam)
+                      else
+                        string_id.gsub(version, version + VERSION_PREFIX + version_timestam)
+                      end
+
+          self.class.new(Valkyrie::ID.new(id_string))
+        end
+
+        def current_timestamp
+          Time.now.utc.strftime("%s%L")
+        end
+
+        def deletion_marker?
+          string_id.include?(DELETION_MARKER)
+        end
+
+        # @return [Boolean] Whether this id is referential (e.g. "current") or absolute (e.g. a timestamp)
+        def reference?
+          version == CURRENT_VERSION
+        end
+
+        def versioned?
+          string_id.include?(VERSION_PREFIX)
+        end
+
+        def version
+          string_id.split("/").last.split(VERSION_PREFIX).last
+        end
+
+        def string_id
+          id.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/valkyrie/storage/versioned_shrine.rb
+++ b/lib/valkyrie/storage/versioned_shrine.rb
@@ -61,14 +61,13 @@ module Valkyrie
       # @param file [IO]
       def upload_version(id:, file:, **upload_options)
         versioned_shrine_id = shrine_id_for(VersionId.new(id).generate_version.id)
-        uploaded_version = upload_file(file: file, identifier: versioned_shrine_id, **upload_options)
 
         # For backward compatablity with files ingested in the past and we don't have to migrate it to versioned fies.
         #   If there is a file associated with the given identifier that is not a versioned file,
         #   simply convert it to a versioned file basing on last_modified time to keep all versioned files consistent.
         to_version_file(id: id) if shrine.exists?(shrine_id_for(id))
 
-        uploaded_version
+        upload_file(file: file, identifier: versioned_shrine_id, **upload_options)
       end
 
       # Delete the versioned file or delete all versions in S3 associated with the given identifier.

--- a/spec/support/s3_helper.rb
+++ b/spec/support/s3_helper.rb
@@ -42,6 +42,15 @@ class S3Helper
     }
   end
 
+  def delete_objects
+    lambda { |context|
+      bucket = context.params[:bucket]
+      objs = context.params[:delete][:objects]
+      objs.map { |obj| obj[:key] }.each { |k| s3_cache[bucket].delete(k) }
+      {}
+    }
+  end
+
   def head_object
     lambda { |context|
       bucket = context.params[:bucket]
@@ -96,6 +105,7 @@ class S3Helper
         create_bucket: create_bucket,
         copy_object: copy_object,
         delete_object: delete_object,
+        delete_objects: delete_objects,
         head_object: head_object,
         list_objects_v2: list_objects_v2,
         get_object: get_object,

--- a/spec/valkyrie/shrine/storage/s3_spec.rb
+++ b/spec/valkyrie/shrine/storage/s3_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Valkyrie::Shrine::Storage::S3 do
+  let(:instance) { described_class.new(bucket: bucket, client: s3_client, prefix: storage_prefix) }
+
+  let(:bucket) { "my-bucket" }
+  let(:s3_helper) { S3Helper.new }
+  let(:s3_client) { s3_helper.client }
+  let(:s3_cache) { s3_helper.s3_cache }
+
+  let(:object_id) { "object/id" }
+  let(:version1) { storage_prefix.blank? ? "#{object_id}_v-1" : "#{storage_prefix}/#{object_id}_v-1" }
+  let(:version2) { storage_prefix.blank? ? "#{object_id}_v-2" : "#{storage_prefix}/#{object_id}_v-2" }
+
+  before do
+    s3_cache[bucket] = {}
+  end
+
+  describe "#list_object_ids" do
+    context "with no storage prefix" do
+      let(:storage_prefix) { nil }
+
+      before do
+        s3_cache[bucket] = { version1 => "Version 1 Content", version2 => "Version 2 Content" }
+      end
+
+      it "returns object id's associated with the prefix" do
+        expect(instance.list_object_ids(id_prefix: object_id))
+          .to contain_exactly("#{object_id}_v-1", "#{object_id}_v-2")
+      end
+    end
+
+    context "with storage prefix" do
+      let(:storage_prefix) { "1234" }
+
+      before do
+        s3_cache[bucket] = { version1 => "Version 1 Content", version2 => "Version 2 Content" }
+      end
+
+      it "returns object id's associated with the prefix" do
+        expect(instance.list_object_ids(id_prefix: object_id))
+          .to contain_exactly("#{object_id}_v-1", "#{object_id}_v-2")
+      end
+    end
+  end
+end

--- a/spec/valkyrie/shrine/storage/s3_spec.rb
+++ b/spec/valkyrie/shrine/storage/s3_spec.rb
@@ -11,19 +11,20 @@ RSpec.describe Valkyrie::Shrine::Storage::S3 do
   let(:s3_cache) { s3_helper.s3_cache }
 
   let(:object_id) { "object/id" }
-  let(:version1) { storage_prefix.blank? ? "#{object_id}_v-1" : "#{storage_prefix}/#{object_id}_v-1" }
-  let(:version2) { storage_prefix.blank? ? "#{object_id}_v-2" : "#{storage_prefix}/#{object_id}_v-2" }
 
   before do
     s3_cache[bucket] = {}
   end
 
   describe "#list_object_ids" do
+    let(:version1) { storage_prefix.blank? ? "#{object_id}_v-1" : "#{storage_prefix}/#{object_id}_v-1" }
+    let(:version2) { storage_prefix.blank? ? "#{object_id}_v-2" : "#{storage_prefix}/#{object_id}_v-2" }
+
     context "with no storage prefix" do
       let(:storage_prefix) { nil }
 
       before do
-        s3_cache[bucket] = { version1 => "Version 1 Content", version2 => "Version 2 Content" }
+        s3_cache[bucket] = { version1 => {}, version2 => {} }
       end
 
       it "returns object id's associated with the prefix" do
@@ -36,12 +37,46 @@ RSpec.describe Valkyrie::Shrine::Storage::S3 do
       let(:storage_prefix) { "1234" }
 
       before do
-        s3_cache[bucket] = { version1 => "Version 1 Content", version2 => "Version 2 Content" }
+        s3_cache[bucket] = { version1 => {}, version2 => {} }
       end
 
       it "returns object id's associated with the prefix" do
         expect(instance.list_object_ids(id_prefix: object_id))
           .to contain_exactly("#{object_id}_v-1", "#{object_id}_v-2")
+      end
+    end
+  end
+
+  describe "#move_to" do
+    let(:source_storage_id) { storage_prefix.blank? ? object_id : "#{storage_prefix}/#{object_id}" }
+    let(:destination_id) { "#{object_id}_v-1" }
+    let(:destination_storage_id) { storage_prefix.blank? ? destination_id : "#{storage_prefix}/#{destination_id}" }
+
+    context "with no storage prefix" do
+      let(:storage_prefix) { nil }
+
+      before do
+        s3_cache[bucket] = { source_storage_id => {} }
+      end
+
+      it "move the file to destination" do
+        destination_key = instance.move_to(id: object_id, destination_id: destination_id)
+        expect(destination_key).to end_with(destination_storage_id)
+        expect(s3_cache[bucket].keys).to contain_exactly(destination_storage_id)
+      end
+    end
+
+    context "with storage prefix" do
+      let(:storage_prefix) { "1234" }
+
+      before do
+        s3_cache[bucket] = { source_storage_id => {} }
+      end
+
+      it "move the file to destination" do
+        destination_key = instance.move_to(id: object_id, destination_id: destination_id)
+        expect(destination_key).to end_with(destination_storage_id)
+        expect(s3_cache[bucket].keys).to contain_exactly(destination_storage_id)
       end
     end
   end

--- a/spec/valkyrie/shrine/storage/s3_spec.rb
+++ b/spec/valkyrie/shrine/storage/s3_spec.rb
@@ -117,8 +117,8 @@ RSpec.describe Valkyrie::Shrine::Storage::S3 do
 
     let(:version1) { storage_prefix.blank? ? "#{object_id}_v-1" : "#{storage_prefix}/#{object_id}_v-1" }
     let(:version2) { storage_prefix.blank? ? "#{object_id}_v-2" : "#{storage_prefix}/#{object_id}_v-2" }
-    let(:object_version1) { double(bucket_name: bucket, key: version1) }
-    let(:object_version2) { double(bucket_name: bucket, key: version2) }
+    let(:object_version1) { instance_double(Aws::S3::Object, bucket_name: bucket, key: version1) }
+    let(:object_version2) { instance_double(Aws::S3::Object, bucket_name: bucket, key: version2) }
 
     context "with no storage prefix" do
       let(:storage_prefix) { nil }

--- a/spec/valkyrie/storage/versioned_shrine_spec.rb
+++ b/spec/valkyrie/storage/versioned_shrine_spec.rb
@@ -239,14 +239,14 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
     let(:identifier) { Valkyrie::ID.new("shrine://a/fake-id") }
 
     it "creates a version id" do
-      expect(version_id.generate_version.string_id).to include("_v-")
+      expect(version_id.new_version).to include("_v-")
     end
 
     context "with a timstamp" do
       let(:timestamp) { Time.now.utc - 1 / 24.0 }
 
       it "creates a version id" do
-        expect(version_id.generate_version(timestamp: timestamp).string_id)
+        expect(version_id.new_version(timestamp: timestamp))
           .to eq("#{identifier}_v-#{timestamp.strftime('%s%L')}")
       end
     end
@@ -256,8 +256,8 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
 
       it "creates a new version id" do
         expect(version_id.version).to eq("1694195675462560794")
-        expect(version_id.generate_version.string_id).to include("_v-")
-        expect(version_id.generate_version.version).not_to eq("1694195675462560794")
+        expect(version_id.new_version).to include("_v-")
+        expect(version_id.new_version).not_to eq("1694195675462560794")
       end
     end
   end

--- a/spec/valkyrie/storage/versioned_shrine_spec.rb
+++ b/spec/valkyrie/storage/versioned_shrine_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
       let(:shrine_id_uploaded) { uploaded_file.id.to_s.sub(/^#{protocol_with_prefix}/, "") }
 
       it "renames the file to a versioned file" do
-        expect(uploaded_file.version_id.to_s).not_to include("_v-")
+        expect(uploaded_file.version_id.to_s).not_to include("/v-")
 
         expect(s3_adapter.list_object_ids(id_prefix: shrine_id_uploaded).last).to eq(shrine_id_uploaded)
 
@@ -103,7 +103,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
 
         expect(list_object_ids.size).to eq(2)
         expect(list_object_ids.last).not_to eq(shrine_id_uploaded)
-        expect(list_object_ids.last).to include("#{shrine_id_uploaded}_v-")
+        expect(list_object_ids.last).to include("#{shrine_id_uploaded}/v-")
         expect(list_object_ids.first).to include(uploaded_version.id.to_s.split(protocol_with_prefix).last)
       end
     end
@@ -169,7 +169,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
     let!(:shrine_version_id) { uploaded_version.version_id.to_s.split(protocol).last }
 
     it "raises FileNotFound error" do
-      expect { storage_adapter.delete(id: "a_fake_id_v-version-id") }
+      expect { storage_adapter.delete(id: "a_fake_id/v-version-id") }
         .to raise_error Valkyrie::StorageAdapter::FileNotFound
     end
 
@@ -225,7 +225,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
     let(:identifier) { Valkyrie::ID.new("shrine://a/fake-id") }
 
     it "creates a version id" do
-      expect(version_id.new_version).to include("_v-")
+      expect(version_id.new_version).to include("/v-")
     end
 
     context "with a timstamp" do
@@ -233,17 +233,17 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
 
       it "creates a version id" do
         expect(version_id.new_version(timestamp: timestamp))
-          .to eq("#{identifier}_v-#{timestamp.strftime('%s%L')}")
+          .to eq("#{identifier}/v-#{timestamp.strftime('%Y%m%d%H%M%S%L')}")
       end
     end
 
     context "with a version id" do
-      let(:identifier) { Valkyrie::ID.new("shrine://a/fake-id_v-1694195675462560794") }
+      let(:identifier) { Valkyrie::ID.new("shrine://a/fake-id/v-20250429142441274") }
 
       it "creates a new version id" do
-        expect(version_id.version).to eq("1694195675462560794")
-        expect(version_id.new_version).to include("_v-")
-        expect(version_id.new_version).not_to eq("1694195675462560794")
+        expect(version_id.version).to eq("20250429142441274")
+        expect(version_id.new_version).to include("/v-")
+        expect(version_id.new_version).not_to eq("20250429142441274")
       end
     end
   end

--- a/spec/valkyrie/storage/versioned_shrine_spec.rb
+++ b/spec/valkyrie/storage/versioned_shrine_spec.rb
@@ -110,10 +110,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
   end
 
   describe "#find_by" do
-    before do
-      uploaded_file
-      uploaded_version
-    end
+    before { uploaded_version }
 
     it "find the latest versioned file" do
       expect(storage_adapter.find_by(id: uploaded_file.id))
@@ -124,10 +121,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
   describe "#find_versions" do
     subject(:find_versions) { storage_adapter.find_versions(id: uploaded_file.id) }
 
-    before do
-      uploaded_file
-      uploaded_version
-    end
+    before { uploaded_version }
 
     it "find all active versions" do
       expect(find_versions.size).to eq(2)
@@ -151,10 +145,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
   describe "#version_files" do
     subject(:version_files) { storage_adapter.version_files(id: uploaded_file.id) }
 
-    before do
-      uploaded_file
-      uploaded_version
-    end
+    before { uploaded_version }
 
     context "with all versioned files" do
       it "returns all versioned files" do
@@ -213,10 +204,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
     subject(:version_id) { storage_adapter.resolve_current(id) }
     let(:id) { uploaded_version.version_id }
 
-    before do
-      uploaded_file
-      uploaded_version
-    end
+    before { uploaded_version }
 
     it "returns the versioned ID" do
       expect(version_id.id).to eq(uploaded_version.version_id)

--- a/spec/valkyrie/storage/versioned_shrine_spec.rb
+++ b/spec/valkyrie/storage/versioned_shrine_spec.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'valkyrie'
+require 'valkyrie/specs/shared_specs'
+require 'shrine/storage/s3'
+require 'action_dispatch'
+include ActionDispatch::TestProcess
+
+RSpec.describe Valkyrie::Storage::VersionedShrine do
+  let(:s3_adapter) { Valkyrie::Shrine::Storage::S3.new(bucket: s3_bucket, client: s3_client) }
+  let(:storage_adapter) { described_class.new(s3_adapter, verifier, identifier_prefix: identifier_prefix) }
+
+  let(:s3_bucket) { "my-bucket" }
+  let(:s3_client) { S3Helper.new.client }
+
+  let(:protocol) { Valkyrie::Storage::Shrine::PROTOCOL }
+  let(:identifier_prefix) { "1234" }
+  let(:protocol_with_prefix) { [identifier_prefix, protocol].reject(&:blank?).join("-") }
+
+  let(:verifier) { NullVerifier }
+  let(:resource) { ExampleResource.new(id: "fake-resource-id") }
+  let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+  let(:uploaded_file) { storage_adapter.upload(file: file, original_filename: "example.tif", resource: resource, fake_upload_argument: true) }
+
+  let(:version_file) { Rack::Test::UploadedFile.new(StringIO.new("Test  Versioned File Content"), "text/plain", true, original_filename: "versioned.txt") }
+  let(:uploaded_version) { storage_adapter.upload_version(id: uploaded_file.id, file: version_file) }
+
+  before do
+    class ExampleResource < Valkyrie::Resource
+    end
+
+    class NullVerifier
+      def self.verify_checksum(_io, _result)
+        true
+      end
+    end
+
+    s3_client.create_bucket(bucket: s3_bucket)
+  end
+
+  after do
+    Object.send(:remove_const, :ExampleResource)
+    Object.send(:remove_const, :NullVerifier)
+  end
+
+  context 'Default verifier' do
+    let(:verifier) { nil }
+
+    it_behaves_like 'a Valkyrie::StorageAdapter'
+  end
+
+  context 'Custom verifier' do
+    let(:verifier) { double }
+    it_behaves_like 'a Valkyrie::StorageAdapter'
+
+    before do
+      allow(verifier).to receive(:verify_checksum).and_return(true)
+    end
+  end
+
+  describe "#upload" do
+    it "only reads from the client when the content is actually read out" do
+      allow(s3_adapter).to receive(:open).and_call_original
+
+      uploaded_file
+
+      expect(s3_adapter).not_to have_received(:open)
+
+      uploaded_file.read
+      expect(s3_adapter).to have_received(:open)
+    end
+  end
+
+  describe "#upload_version" do
+    it "upload a versioned file" do
+      uploaded_file
+
+      allow(s3_adapter).to receive(:open).and_call_original
+
+      uploaded_version = storage_adapter.upload_version(id: uploaded_file.id, file: version_file)
+
+      uploaded_version.read
+      expect(s3_adapter).to have_received(:open)
+    end
+
+    context "non-versioned file with the identifier(:id) exists" do
+      subject(:list_object_ids) { s3_adapter.list_object_ids(id_prefix: shrine_id_uploaded).sort.reverse }
+
+      # Upload a non-versioned file with Valkyrie::Storage::Shrine and Shrine::Storage::S3
+      let(:shrine_s3_adapter) { Shrine::Storage::S3.new(bucket: s3_bucket, client: s3_client) }
+      let(:shrine_storage_adapter) { Valkyrie::Storage::Shrine.new(shrine_s3_adapter, verifier, identifier_prefix: identifier_prefix) }
+      let!(:uploaded_file) { shrine_storage_adapter.upload(file: file, original_filename: "text.txt", resource: resource, fake_upload_argument: true) }
+
+      let(:shrine_id_uploaded) { uploaded_file.id.to_s.sub(/^#{protocol_with_prefix}/, "") }
+
+      it "renames the file to a versioned file" do
+        expect(uploaded_file.version_id.to_s).not_to include("_v-")
+
+        expect(s3_adapter.list_object_ids(id_prefix: shrine_id_uploaded).last).to eq(shrine_id_uploaded)
+
+        uploaded_version
+
+        expect(list_object_ids.size).to eq(2)
+        expect(list_object_ids.last).not_to eq(shrine_id_uploaded)
+        expect(list_object_ids.last).to include("#{shrine_id_uploaded}_v-")
+        expect(list_object_ids.first).to include(uploaded_version.id.to_s.split(protocol_with_prefix).last)
+      end
+    end
+  end
+
+  describe "#find_by" do
+    before do
+      uploaded_file
+      uploaded_version
+    end
+
+    it "find the latest versioned file" do
+      expect(storage_adapter.find_by(id: uploaded_file.id))
+        .to have_attributes(id: uploaded_version.id, version_id: uploaded_version.version_id)
+    end
+  end
+
+  describe "#find_versions" do
+    subject(:find_versions) { storage_adapter.find_versions(id: uploaded_file.id) }
+
+    before do
+      uploaded_file
+      uploaded_version
+    end
+
+    it "find all active versions" do
+      expect(find_versions.size).to eq(2)
+    end
+
+    context "with versioned file deleted" do
+      let!(:previous_version_id) { storage_adapter.version_files(id: uploaded_file.id).last }
+
+      it "excludes versions with deletion marker" do
+        expect(find_versions.map(&:version_id)).to include(previous_version_id)
+
+        versions_deleted = storage_adapter.delete(id: previous_version_id)
+
+        expect(versions_deleted.first.to_s).to include("deletionmarker")
+        expect(storage_adapter.find_versions(id: uploaded_file.id).map(&:version_id))
+          .not_to include(previous_version_id)
+      end
+    end
+  end
+
+  describe "#version_files" do
+    subject(:version_files) { storage_adapter.version_files(id: uploaded_file.id) }
+
+    before do
+      uploaded_file
+      uploaded_version
+    end
+
+    context "with all versioned files" do
+      it "returns all versioned files" do
+        expect(version_files.size).to eq(2)
+      end
+    end
+
+    context "with versioned file deleted" do
+      it "includes versioned files with deletion marker" do
+        versions_deleted = storage_adapter.delete(id: uploaded_version.id)
+
+        expect(versions_deleted.first.to_s).to include("deletionmarker")
+        expect(storage_adapter.version_files(id: uploaded_file.id))
+          .to include(versions_deleted.first.id)
+      end
+    end
+  end
+
+  describe "#delete" do
+    before do
+      uploaded_file
+      uploaded_version
+    end
+
+    context "a versioned file assiciated with the given identifier" do
+      subject(:list_object_ids) { s3_adapter.list_object_ids(id_prefix: shrine_id_uploaded).sort.reverse }
+
+      let(:shrine_id_uploaded) { uploaded_file.id.to_s.split(protocol).last }
+      let(:shrine_version_id) { uploaded_version.version_id.to_s.split(protocol).last }
+
+      it "marks the versioned file with deletion marker" do
+        versions_deleted = storage_adapter.delete(id: uploaded_version.version_id).map(&:to_s)
+        expect(versions_deleted)
+          .to contain_exactly("#{uploaded_version.version_id}-deletionmarker")
+        expect(s3_adapter.list_object_ids(id_prefix: shrine_id_uploaded).sort.reverse)
+          .to include("#{shrine_version_id}-deletionmarker")
+      end
+    end
+
+    context "with all versioned files assiciated with the given identifier" do
+      let!(:version_files) { storage_adapter.version_files(id: uploaded_file.id) }
+
+      it "marks all version files' identifiers with deletion marker" do
+        expect(storage_adapter.version_files(id: uploaded_file.id).size).to eq(2)
+        expect(storage_adapter.delete(id: uploaded_file.id).map(&:to_s))
+          .to contain_exactly("#{version_files.first}-deletionmarker",
+                              "#{version_files.last}-deletionmarker")
+      end
+    end
+  end
+
+  describe "#version_id" do
+    subject(:version_id) { storage_adapter.version_id(id) }
+
+    before do
+      uploaded_file
+      uploaded_version
+    end
+
+    context "with a versioned ID" do
+      let(:id) { uploaded_version.version_id }
+
+      it "returns the versioned ID" do
+        expect(version_id).to be_a(Valkyrie::Storage::VersionedShrine::VersionId)
+        expect(version_id.id).to eq(uploaded_version.version_id)
+      end
+    end
+
+    context "converts a referenced version ID" do
+      let(:id) { Valkyrie::ID.new("#{uploaded_version.id.to_s.split('v-').first}_v-current") }
+
+      it "returns the latest versioned ID" do
+        expect(version_id).to be_a(Valkyrie::Storage::VersionedShrine::VersionId)
+        expect(version_id.id).to eq(uploaded_version.version_id)
+      end
+    end
+  end
+
+  describe "VersionId#generate_version" do
+    subject(:version_id) { Valkyrie::Storage::VersionedShrine::VersionId.new(identifier) }
+
+    let(:identifier) { Valkyrie::ID.new("shrine://a/fake-id") }
+
+    it "creates a version id" do
+      expect(version_id.generate_version.string_id).to include("_v-")
+    end
+
+    context "with a timstamp" do
+      let(:timestamp) { Time.now.utc - 1 / 24.0 }
+
+      it "creates a version id" do
+        expect(version_id.generate_version(timestamp: timestamp).string_id)
+          .to eq("#{identifier}_v-#{timestamp.strftime('%s%L')}")
+      end
+    end
+
+    context "with a version id" do
+      let(:identifier) { Valkyrie::ID.new("shrine://a/fake-id_v-1694195675462560794") }
+
+      it "creates a new version id" do
+        expect(version_id.version).to eq("1694195675462560794")
+        expect(version_id.generate_version.string_id).to include("_v-")
+        expect(version_id.generate_version.version).not_to eq("1694195675462560794")
+      end
+    end
+  end
+end

--- a/spec/valkyrie/storage/versioned_shrine_spec.rb
+++ b/spec/valkyrie/storage/versioned_shrine_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
   end
 
   describe "#version_id" do
-    subject(:version_id) { storage_adapter.version_id(id) }
+    subject(:version_id) { storage_adapter.resolve_current(id) }
 
     before do
       uploaded_file

--- a/spec/valkyrie/storage/versioned_shrine_spec.rb
+++ b/spec/valkyrie/storage/versioned_shrine_spec.rb
@@ -209,28 +209,23 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
     end
   end
 
-  describe "#version_id" do
+  describe "#resolve_current" do
     subject(:version_id) { storage_adapter.resolve_current(id) }
+    let(:id) { uploaded_version.version_id }
 
     before do
       uploaded_file
       uploaded_version
     end
 
-    context "with a versioned ID" do
-      let(:id) { uploaded_version.version_id }
-
-      it "returns the versioned ID" do
-        expect(version_id).to be_a(Valkyrie::Storage::VersionedShrine::VersionId)
-        expect(version_id.id).to eq(uploaded_version.version_id)
-      end
+    it "returns the versioned ID" do
+      expect(version_id.id).to eq(uploaded_version.version_id)
     end
 
-    context "converts a referenced version ID" do
-      let(:id) { Valkyrie::ID.new("#{uploaded_version.id.to_s.split('v-').first}_v-current") }
+    context "with a base identifier that is not a version" do
+      let(:id) { uploaded_version.id }
 
       it "returns the latest versioned ID" do
-        expect(version_id).to be_a(Valkyrie::Storage::VersionedShrine::VersionId)
         expect(version_id.id).to eq(uploaded_version.version_id)
       end
     end

--- a/spec/valkyrie/storage/versioned_shrine_spec.rb
+++ b/spec/valkyrie/storage/versioned_shrine_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
 
         versions_deleted = storage_adapter.delete(id: previous_version_id)
 
-        expect(versions_deleted.first).to include(previous_version_id)
+        expect(versions_deleted.first).to eq(previous_version_id)
         expect(storage_adapter.find_versions(id: uploaded_file.id).map(&:version_id))
           .not_to include(previous_version_id)
       end
@@ -233,7 +233,7 @@ RSpec.describe Valkyrie::Storage::VersionedShrine do
     end
   end
 
-  describe "VersionId#generate_version" do
+  describe "VersionId#new_version" do
     subject(:version_id) { Valkyrie::Storage::VersionedShrine::VersionId.new(identifier) }
 
     let(:identifier) { Valkyrie::ID.new("shrine://a/fake-id") }


### PR DESCRIPTION
Refs #20 

Implementation option 2 to support versioning on AWS/S3 with the original shrine storage file identifier as prefix and postfixing a timestamp as part of the version label like  shrine://[resource_id]/[UUID]_v-[timestamp]. The implementation is similar to VersionedDisk. 

There could be some open questions:
- What delimiter do we want to use as prefix for the version label (v-[timestamp]), underscore (_), slash (/) etc.? 
- Do we allow ingest/upload files with a normal file identifier instead of a version id?

### Manual test
Register storage adapter Valkyrie::Storage::VersionedShrine:
```
    shrine_s3_options = {
          access_key_id: s3_access_key,
          bucket: s3_bucket,
          endpoint: s3_endpoint,
          force_path_style: force_path_style,
          region: s3_region,
          secret_access_key: s3_secret_key
        }
        Valkyrie::StorageAdapter.register(
          Valkyrie::Storage::VersionedShrine.new(Valkyrie::Shrine::Storage::S3.new(**shrine_s3_options)),
          :s3_repository
        )
Valkyrie.config.storage_adapter = :s3_repository
```
